### PR TITLE
Fixes to groups option

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class duo_unix::params {
     }
     'RedHat': {
       $duo_package = 'duo_unix'
-      $ssh_service = 'ssh'
+      $ssh_service = 'sshd'
       $pam_file = $facts['os']['release']['major'] ? {
         '5' => '/etc/pam.d/system-auth',
         default => '/etc/pam.d/password-auth',

--- a/templates/duo.conf.erb
+++ b/templates/duo.conf.erb
@@ -35,10 +35,10 @@ accept_env_factor=<%= @accept_env_factor %>
 ; MOTD display
 motd=<%= @motd %>
 <% end -%>
-<% if defined?(@group) -%>
+<% if defined?(@groups) -%>
 
 ; Group restriction
-groups=<%= @group %>
+groups=<%= @groups %>
 <% end -%>
 <% if defined?(@http_proxy) -%>
 


### PR DESCRIPTION
Fixing groups variable name in duo.conf template to allow the groups option to work.