### PR TITLE
Fix repos and groups usage

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -37,10 +37,10 @@ class duo_unix::repo {
     'RedHat': {
       yumrepo { 'duosecurity':
         ensure   => 'present',
-        enabled  => true,
+        enabled  => '1',
         descr    => 'Duo Inc. officical repository',
         baseurl  => "${pkg_base_url}/${facts['os']['name']}/\$releasever/\$basearch",
-        gpgcheck => true,
+        gpgcheck => '1',
         gpgkey   => 'https://duo.com/RPM-GPG-KEY-DUO',
       }
     }

--- a/templates/duo.conf.erb
+++ b/templates/duo.conf.erb
@@ -35,10 +35,10 @@ accept_env_factor=<%= @accept_env_factor %>
 ; MOTD display
 motd=<%= @motd %>
 <% end -%>
-<% if defined?(@group) -%>
+<% if defined?(@groups) -%>
 
 ; Group restriction
-groups=<%= @group %>
+groups=<%= @groups %>
 <% end -%>
 <% if defined?(@http_proxy) -%>
 


### PR DESCRIPTION
Yum repos usually use 1/0 and not `True`/`False` which is what `true`/`false` get mapped to in Puppet which maybe works but not common.

Also the variable usage for `groups` was missing `s` in template.