### PR TITLE
Fix parameter usage in templates

### DIFF
--- a/templates/duo.conf.erb
+++ b/templates/duo.conf.erb
@@ -35,13 +35,13 @@ accept_env_factor=<%= @accept_env_factor %>
 ; MOTD display
 motd=<%= @motd %>
 <% end -%>
-<% if defined?(@groups) -%>
+<% if @groups -%>
 
 ; Group restriction
 groups=<%= @groups %>
 <% end -%>
-<% if defined?(@http_proxy) -%>
+<% if @proxy -%>
 
 ; HTTP proxy
-http_proxy=<%= @http_proxy %>
+http_proxy=<%= @proxy %>
 <% end -%>


### PR DESCRIPTION
Even with #7 the `groups` was not getting setting.  Pretty sure `defined?` doesn't work. Just checking `if @something` is good enough since `undef` is `nil` in templates. Also the proxy parameter was wrong, so updated template to avoid parameter change.