### PR TITLE
Make repo management conditional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class duo_unix (
   Boolean $manage_repo                        = $duo_unix::params::manage_repo,
   Enum['latest', 'present', 'absent'] $ensure = $duo_unix::params::ensure,
   Enum['no', 'yes'] $fallback_local_ip        = $duo_unix::params::fallback_local_ip,
-  Enum['fail', 'safe'] $failmode              = $duo_unix::params::failmode,
+  Enum['secure', 'safe'] $failmode            = $duo_unix::params::failmode,
   Enum['no', 'yes'] $pushinfo                 = $duo_unix::params::pushinfo,
   Enum['no', 'yes'] $autopush                 = $duo_unix::params::autopush,
   Enum['no', 'yes'] $motd                     = $duo_unix::params::motd,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class duo_unix::params {
   $ensure             = 'present'
   $manage_pam         = true
   $manage_ssh         = true
+  $manage_repo        = true
   $fallback_local_ip  = 'no'
   $failmode           = 'safe'
   $pushinfo           = 'no'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -34,7 +34,7 @@ class duo_unix::repo inherits duo_unix::params {
         },
       }
 
-     Apt::Source['duosecurity'] -> Package<| title == $duo_unix::params::duo_package |>
+      Apt::Source['duosecurity'] -> Package<| title == $duo_unix::params::duo_package |>
     }
     'RedHat': {
       yumrepo { 'duosecurity':

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,7 +9,7 @@
 # @example
 #   include duo_unix::repo
 #
-class duo_unix::repo {
+class duo_unix::repo inherits duo_unix::params {
   $pkg_base_url = 'https://pkg.duosecurity.com'
 
   case $facts['os']['family'] {
@@ -33,6 +33,8 @@ class duo_unix::repo {
           source => 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc',
         },
       }
+
+     Apt::Source['duosecurity'] -> Package<| title == $duo_unix::params::duo_package |>
     }
     'RedHat': {
       yumrepo { 'duosecurity':
@@ -43,6 +45,8 @@ class duo_unix::repo {
         gpgkey   => 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc',
         gpgcheck => '1',
       }
+
+      Yumrepo['duosecurity'] -> Package<| title == $duo_unix::params::duo_package |>
     }
     default: {
       fail("Module ${module_name} does not support ${facts['os']['release']['full']}")

--- a/spec/classes/duo_unix_spec.rb
+++ b/spec/classes/duo_unix_spec.rb
@@ -51,14 +51,14 @@ describe 'duo_unix' do
       }
     end
 
-    context "with unmanaged repos" do
+    context 'with unmanaged repos' do
       let(:params) do
         {
           'usage'       => 'login',
           'ikey'        => 'testikey',
           'skey'        => 'testskey',
           'host'        => 'api-XXXXXXXX.duosecurity.com',
-          'manage_repo' => false
+          'manage_repo' => false,
         }
       end
       let(:facts) { os_facts }

--- a/spec/classes/duo_unix_spec.rb
+++ b/spec/classes/duo_unix_spec.rb
@@ -15,12 +15,14 @@ describe 'duo_unix' do
 
       it { is_expected.to compile.with_all_deps }
 
-      if os =~ %r{/(?:debian|ubuntu).*/}
-        it { is_expected.to contain_package('duo-unix') }
+      if os =~ %r{(?:debian|ubuntu).*}
+        it { is_expected.to contain_package('duo-unix').that_requires('Apt::Source[duosecurity]') }
+        it { is_expected.to contain_apt__source('duosecurity') }
       end
 
-      if os =~ %r{/(?:centos|redhat).*/}
-        it { is_expected.to contain_package('duo_unix') }
+      if os =~ %r{(?:centos|redhat).*}
+        it { is_expected.to contain_package('duo_unix').that_requires('Yumrepo[duosecurity]') }
+        it { is_expected.to contain_yumrepo('duosecurity') }
       end
 
       it {
@@ -47,6 +49,23 @@ describe 'duo_unix' do
           .with_ensure('latest')
           .with_owner('root')
       }
+    end
+
+    context "with unmanaged repos" do
+      let(:params) do
+        {
+          'usage'       => 'login',
+          'ikey'        => 'testikey',
+          'skey'        => 'testskey',
+          'host'        => 'api-XXXXXXXX.duosecurity.com',
+          'manage_repo' => false
+        }
+      end
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.not_to contain_apt__source('duosecurity') }
+      it { is_expected.not_to contain_yumrepo('duosecurity') }
     end
   end
 end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -7,7 +7,7 @@ describe 'duo_unix::repo' do
 
       it { is_expected.to compile.with_all_deps }
 
-      if os =~ %r{/ubuntu.*/}
+      if os =~ %r{ubuntu.*}
 
         if os != 'ubuntu-18.04-x86_64'
           it {
@@ -29,15 +29,15 @@ describe 'duo_unix::repo' do
 
       end
 
-      if os =~ %r{/debian.*/}
+      if os =~ %r{debian.*}
         it { is_expected.to contain_apt__source('duosecurity').with_location('https://pkg.duosecurity.com/Debian') }
       end
 
-      if os =~ %r{/redhat.*/}
+      if os =~ %r{redhat.*}
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/RedHat/$releasever/$basearch') }
       end
 
-      if os =~ %r{/centos.*/}
+      if os =~ %r{centos.*}
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOS/$releasever/$basearch') }
       end
     end


### PR DESCRIPTION
This change allow the management of the duo repositories to be disabled. I'm working in an environment that uses subscription-manager to provide the duo repositories so I do not want the default yum repo to be added.

I also fixed the enumeration values for the failmode param and the OS regexps in the unit tests. The regexps were using both %r{} and // syntax which was preventing them from matching any OS.

Thanks for providing this module!