### PR TITLE
Adding support for Rocky and Alma Linux (using RHEL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Release 2.1.0
+* Added initial support for Rocky and Alma Linux
+  * They will be using the RedHat version of Puppet, not CentOS
+
 ## Release 2.0.0
 * Removed older unsupported versions of various operating systems
   * This is why this is version 2x

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -71,11 +71,16 @@ class duo_unix::repo inherits duo_unix::params {
       Apt::Source['duosecurity'] -> Package<| title == $duo_unix::params::duo_package |>
     }
     'RedHat': {
+      $osname = $facts['os']['name'] ? {
+        'CentOS'    => 'CentOS',
+        default     => 'RedHat',
+      }
+
       yumrepo { 'duosecurity':
         ensure   => 'present',
         enabled  => '1',
         descr    => 'Duo Inc. officical repository',
-        baseurl  => "${pkg_base_url}/${facts['os']['name']}/\$releasever/\$basearch",
+        baseurl  => "${pkg_base_url}/${osname}/\$releasever/\$basearch",
         gpgkey   => 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc',
         gpgcheck => '1',
       }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "iu-duo_unix",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Anthony Vitacco <avitacco@iu.edu>",
   "summary": "Installs, configures, and manages Duo Unix",
   "license": "MIT",
@@ -60,6 +60,18 @@
         "14.04",
         "16.04",
         "18.04"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],

--- a/provision.yaml
+++ b/provision.yaml
@@ -2,23 +2,21 @@
 default:
   provisioner: docker
   images:
-    - 'litmusimage/ubuntu:18.04'
-    - 'centos:8'
+    - 'ubuntu:20.04'
+    - 'ubuntu:18.04'
+    - 'litmusimage/centos:8'
 ubuntu:
   provisioner: docker
   images:
-    - 'litmusimage/ubuntu:14.04'
-    - 'litmusimage/ubuntu:16.04'
-    - 'litmusimage/ubuntu:18.04'
+    - 'ubuntu:18.04'
+    - 'ubuntu:20.04'
 debian:
   provisioner: docker
   images:
-    - 'litmusimage/debian:8'
-    - 'litmusimage/debian:9'
-    - 'litmusimage/debian:10'
+    - 'debian:9'
+    - 'debian:10'
 centos:
   provisioner: docker
   images:
-    - 'centos:6'
-    - 'centos:7'
-    - 'centos:8'
+    - 'litmusimage/centos:7'
+    - 'litmusimage/centos:8'

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -40,6 +40,15 @@ describe 'duo_unix::repo' do
       if os =~ %r{centos.*}
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOS/$releasever/$basearch') }
       end
+
+      if os =~ %r{rocky.*}
+        it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/RedHat/$releasever/$basearch') }
+      end
+      
+      if os =~ %r{alma.*}
+        it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/RedHat/$releasever/$basearch') }
+      end
+      
     end
   end
 end


### PR DESCRIPTION
This PR _should_ add support for Rocky and Alma. The new functionality has been tested with unit tests, but litmus does not currently support Rocky or Alma so it has not passed acceptance tests. I have verified that the changes don't break any currently supported OS though.