### PR TITLE
Updated duo module

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM puppet/pdk:latest
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	]
+}

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,5 +16,5 @@ fixtures:
     stdlib: "puppetlabs/stdlib"
     concat: "puppetlabs/concat"
   symlinks:
-    duo: "#{source_dir}"
+    duo_unix: "#{source_dir}"
 

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,10 +5,9 @@ fixtures:
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
+    provision: 'https://github.com/puppetlabs/provision.git'
   forge_modules:
     augeas_core: "puppetlabs/augeas_core"
-    yumrepo_core: "puppetlabs/yumrepo_core"
     yumrepo_core: "puppetlabs/yumrepo_core"
     inifile: "puppetlabs/inifile"
     apt: "puppetlabs/apt"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,32 +3,18 @@
 ---
 fixtures:
   repositories:
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'git://github.com/puppetlabs/provision.git'
   forge_modules:
     augeas_core: "puppetlabs/augeas_core"
     yumrepo_core: "puppetlabs/yumrepo_core"
-    facts:
-      repo: "puppetlabs-facts"
-      ref: "1.0.0"
-    inifile:
-      repo: "puppetlabs-inifile"
-      ref: "4.1.0"
-    apt:
-      repo: "puppetlabs-apt"
-      ref: "7.3.0"
-    puppet_agent:
-      repo: "puppetlabs-puppet_agent"
-      ref: "3.0.2"
-    translate:
-      repo: "puppetlabs-translate"
-      ref: "2.1.0"
-    registry:
-      repo: "puppetlabs-registry"
-      ref: "3.1.0"
-    stdlib:
-      repo: "puppetlabs/stdlib"
-      ref: "6.0.0"
-    concat:
-      repo: "puppetlabs/concat"
-      ref: "6.1.0"
+    yumrepo_core: "puppetlabs/yumrepo_core"
+    inifile: "puppetlabs/inifile"
+    apt: "puppetlabs/apt"
+    registry: "puppetlabs/registry"
+    stdlib: "puppetlabs/stdlib"
+    concat: "puppetlabs/concat"
+  symlinks:
+    duo: "#{source_dir}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,26 +3,27 @@ stages:
   - syntax
   - unit
 
-cache:
-  paths:
-    - vendor/bundle
+default:
+  cache:
+    paths:
+      - vendor/bundle
 
-before_script:
-  - bundle -v
-  - rm Gemfile.lock || true
-  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
-  - "# Set `rubygems_version` in the .sync.yml to set a value"
-  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
-  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
-  - gem --version
-  - bundle -v
-  - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
+  before_script: &before_script
+    - bundle -v
+    - rm Gemfile.lock || true
+    - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+    - "# Set `rubygems_version` in the .sync.yml to set a value"
+    - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+    - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
+    - gem --version
+    - bundle -v
+    - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
 
-syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.5.7-Puppet ~> 6:
+validate lint check rubocop-Ruby 2.5.7-Puppet ~> 6:
   stage: syntax
   image: ruby:2.5.7
   script:
-    - bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+    - bundle exec rake validate lint check rubocop
   variables:
     PUPPET_GEM_VERSION: '~> 6'
 
@@ -34,11 +35,19 @@ parallel_spec-Ruby 2.5.7-Puppet ~> 6:
   variables:
     PUPPET_GEM_VERSION: '~> 6'
 
-parallel_spec-Ruby 2.4.5-Puppet ~> 5:
+validate lint check rubocop-Ruby 2.7.2-Puppet ~> 7:
+  stage: syntax
+  image: ruby:2.7.2
+  script:
+    - bundle exec rake validate lint check rubocop
+  variables:
+    PUPPET_GEM_VERSION: '~> 7'
+
+parallel_spec-Ruby 2.7.2-Puppet ~> 7:
   stage: unit
-  image: ruby:2.4.5
+  image: ruby:2.7.2
   script:
     - bundle exec rake parallel_spec
   variables:
-    PUPPET_GEM_VERSION: '~> 5'
+    PUPPET_GEM_VERSION: '~> 7'
 

--- a/.pdkignore
+++ b/.pdkignore
@@ -25,13 +25,16 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml
 /appveyor.yml
+/.editorconfig
 /.fixtures.yml
 /Gemfile
 /.gitattributes
 /.gitignore
 /.gitlab-ci.yml
 /.pdkignore
+/.puppet-lint.rc
 /Rakefile
 /rakelib/
 /.rspec
@@ -40,3 +43,5 @@
 /.yardopts
 /spec/
 /.vscode/
+/.sync.yml
+/.devcontainer/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
 ---
 require:
+- rubocop-performance
 - rubocop-rspec
-- rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.5'
   Include:
-  - "./**/*.rb"
+  - "**/*.rb"
   Exclude:
   - bin/*
   - ".vendor/**/*"
@@ -18,16 +18,9 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText:
-  Enabled: false
-GetText/DecorateString:
-  Description: We don't want to decorate test output.
-  Exclude:
-  - spec/**/*
-  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -36,14 +29,13 @@ RSpec/BeforeAfterAll:
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
+RSpec/DescribeSymbol:
+  Exclude:
+  - spec/unit/facter/**/*.rb
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
-Style/BracesAroundHashParameters:
-  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
-    See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact
@@ -72,7 +64,7 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
@@ -87,25 +79,169 @@ Style/Documentation:
   - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-GetText/DecorateFunctionMessage:
+Bundler/InsecureProtocolSource:
   Enabled: false
-GetText/DecorateStringFormattingUsingInterpolation:
+Gemspec/DuplicatedAssignment:
   Enabled: false
-GetText/DecorateStringFormattingUsingPercent:
+Gemspec/OrderedDependencies:
+  Enabled: false
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+Gemspec/RubyVersionGlobalsUsage:
+  Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
+Layout/BeginEndAlignment:
+  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+Layout/EmptyComment:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/FirstArgumentIndentation:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/HeredocIndentation:
+  Enabled: false
+Layout/LeadingEmptyLines:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: false
+Lint/BigDecimalNew:
+  Enabled: false
+Lint/BooleanSymbol:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: false
+Lint/DuplicateElsifCondition:
+  Enabled: false
+Lint/DuplicateRequire:
+  Enabled: false
+Lint/DuplicateRescueException:
+  Enabled: false
+Lint/EmptyConditionalBody:
+  Enabled: false
+Lint/EmptyFile:
+  Enabled: false
+Lint/ErbNewArguments:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/HashCompareByIdentity:
+  Enabled: false
+Lint/IdentityComparison:
+  Enabled: false
+Lint/InterpolationCheck:
+  Enabled: false
+Lint/MissingCopEnableDirective:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/NestedPercentLiteral:
+  Enabled: false
+Lint/NonDeterministicRequireOrder:
+  Enabled: false
+Lint/OrderedMagicComments:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/RedundantCopEnableDirective:
+  Enabled: false
+Lint/RedundantRequireStatement:
+  Enabled: false
+Lint/RedundantSafeNavigation:
+  Enabled: false
+Lint/RedundantWithIndex:
+  Enabled: false
+Lint/RedundantWithObject:
+  Enabled: false
+Lint/RegexpAsCondition:
+  Enabled: false
+Lint/ReturnInVoidContext:
+  Enabled: false
+Lint/SafeNavigationConsistency:
+  Enabled: false
+Lint/SafeNavigationWithEmpty:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: false
+Lint/SendWithMixinArgument:
+  Enabled: false
+Lint/ShadowedArgument:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Lint/ToJSON:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: false
+Lint/UnreachableLoop:
+  Enabled: false
+Lint/UriEscapeUnescape:
+  Enabled: false
+Lint/UriRegexp:
+  Enabled: false
+Lint/UselessMethodDefinition:
+  Enabled: false
+Lint/UselessTimes:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
+  Enabled: false
+Metrics/BlockNesting:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
@@ -119,19 +255,265 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Migration/DepartmentName:
+  Enabled: false
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/BlockParameterName:
+  Enabled: false
+Naming/HeredocDelimiterCase:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Performance/BindCall:
+  Enabled: false
+Performance/DeletePrefix:
+  Enabled: false
+Performance/DeleteSuffix:
+  Enabled: false
+Performance/InefficientHashSearch:
+  Enabled: false
+Performance/UnfreezeString:
+  Enabled: false
+Performance/UriDefaultParser:
+  Enabled: false
+RSpec/Be:
+  Enabled: false
+RSpec/Capybara/CurrentPathExpectation:
+  Enabled: false
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+RSpec/Capybara/VisibilityMatcher:
+  Enabled: false
+RSpec/ContextMethod:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/EmptyHook:
+  Enabled: false
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+RSpec/EmptyLineAfterHook:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
-RSpec/MessageExpectation:
+RSpec/ExampleWithoutDescription:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+RSpec/FactoryBot/CreateList:
+  Enabled: false
+RSpec/FactoryBot/FactoryClassName:
+  Enabled: false
+RSpec/HooksBeforeExamples:
+  Enabled: false
+RSpec/ImplicitBlockExpectation:
+  Enabled: false
+RSpec/ImplicitSubject:
+  Enabled: false
+RSpec/LeakyConstantDeclaration:
+  Enabled: false
+RSpec/LetBeforeExamples:
+  Enabled: false
+RSpec/MissingExampleGroupArgument:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/MultipleSubjects:
+  Enabled: false
 RSpec/NestedGroups:
+  Enabled: false
+RSpec/PredicateMatcher:
+  Enabled: false
+RSpec/ReceiveCounts:
+  Enabled: false
+RSpec/ReceiveNever:
+  Enabled: false
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: false
+RSpec/RepeatedIncludeExample:
+  Enabled: false
+RSpec/ReturnFromStub:
+  Enabled: false
+RSpec/SharedExamples:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
+RSpec/UnspecifiedException:
+  Enabled: false
+RSpec/VariableDefinition:
+  Enabled: false
+RSpec/VoidExpect:
+  Enabled: false
+RSpec/Yield:
+  Enabled: false
+Security/Open:
+  Enabled: false
+Style/AccessModifierDeclarations:
+  Enabled: false
+Style/AccessorGrouping:
   Enabled: false
 Style/AsciiComments:
   Enabled: false
+Style/BisectedAttrAccessor:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
+Style/ColonMethodDefinition:
+  Enabled: false
+Style/CombinableLoops:
+  Enabled: false
+Style/CommentedKeyword:
+  Enabled: false
+Style/Dir:
+  Enabled: false
+Style/DoubleCopDisableDirective:
+  Enabled: false
+Style/EmptyBlockParameter:
+  Enabled: false
+Style/EmptyLambdaParameter:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/EvalWithLocation:
+  Enabled: false
+Style/ExpandPathArguments:
+  Enabled: false
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: false
+Style/FloatDivision:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
+Style/KeywordParametersOrder:
+  Enabled: false
+Style/MinMax:
+  Enabled: false
+Style/MixinUsage:
+  Enabled: false
+Style/MultilineWhenThen:
+  Enabled: false
+Style/NegatedUnless:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/OrAssignment:
+  Enabled: false
+Style/RandomWithOffset:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
+Style/RedundantCondition:
+  Enabled: false
+Style/RedundantConditional:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
+  Enabled: false
+Style/RedundantSelfAssignment:
+  Enabled: false
+Style/RedundantSort:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
+Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/Strip:
+  Enabled: false
 Style/SymbolProc:
+  Enabled: false
+Style/TrailingBodyOnClass:
+  Enabled: false
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: false
+Style/TrailingBodyOnModule:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+Style/TrailingMethodEndStatement:
+  Enabled: false
+Style/UnpackFirst:
+  Enabled: false
+Lint/DuplicateBranch:
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: false
+Lint/EmptyBlock:
+  Enabled: false
+Lint/EmptyClass:
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+Lint/ToEnumArguments:
+  Enabled: false
+Lint/UnexpectedBlockArity:
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: false
+Performance/CollectionLiteralInLoop:
+  Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/CollectionCompact:
+  Enabled: false
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+Style/NegatedIfElseCondition:
+  Enabled: false
+Style/NilLambda:
+  Enabled: false
+Style/RedundantArgument:
+  Enabled: false
+Style/SwapValues:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,8 @@ jobs:
   fast_finish: true
   include:
     -
-      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      env: CHECK="validate lint check rubocop"
       stage: static
-    -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.5
-      stage: spec
     -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7
@@ -41,41 +37,9 @@ jobs:
     -
       env: DEPLOY_TO_FORGE=yes
       stage: deploy
-    -
-      before_script:
-        - "bundle exec rake 'litmus:provision_list[ubuntu]'"
-        - "bundle exec rake 'litmus:install_agent'"
-        - "bundle exec rake 'litmus:install_module'"
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    -
-      before_script:
-        - "bundle exec rake 'litmus:provision_list[debian]'"
-        - "bundle exec rake 'litmus:install_agent'"
-        - "bundle exec bolt command run 'apt-get install -y lsb-release' --inventoryfile inventory.yaml --targets 'localhost*'"
-        - "bundle exec rake 'litmus:install_module'"
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    -
-      before_script:
-        - "bundle exec rake 'litmus:provision_list[centos]'"
-        - "bundle exec rake 'litmus:install_agent'"
-        - "bundle exec rake 'litmus:install_module'"
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    -
-      env: DEPLOY_TO_FORGE=yes
-      stage: deploy
-
 branches:
   only:
-    - master
+    - main
     - /^v\d/
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 * Dropped Debian 9 support
 * Added Ubuntu 20.04 support
 * Added CentOS 9 support
-* Added CentOSStream support
 * Added RedHat 9 support
 * Added Debian 11 support
 * Removed deprecated `puppetlabs/translate` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+## Release 3.0.0
+* Fixed unit tests
+* Fixed puppet-lint issues
+* Updated legacy facts
+* Updated PDK
+* Updated DUO GPG keys
+* Updated README
+* Dropped Ubuntu 14.04 support
+* Dropped Ubuntu 16.04 support
+* Dropped CentOS 6 support
+* Dropped Debian 8 support
+* Dropped Debian 9 support
+* Added Ubuntu 20.04 support
+* Added CentOS 9 support
+* Added RedHat 9 support
+* Added Debian 11 support
+* Removed deprecated `puppetlabs/translate` module
+
 ## Release 2.1.1
 * Fixed some code quality issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Dropped Debian 9 support
 * Added Ubuntu 20.04 support
 * Added CentOS 9 support
+* Added CentOSStream support
 * Added RedHat 9 support
 * Added Debian 11 support
 * Removed deprecated `puppetlabs/translate` module

--- a/Gemfile
+++ b/Gemfile
@@ -17,17 +17,18 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
+end
+group :system_tests do
+  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
@@ -43,16 +44,6 @@ gems['puppet'] = location_for(puppet_version)
 
 gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
-
-if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
-  # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
-  # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
-  gems['win32-dir'] =      ['<= 0.4.9', require: false]
-  gems['win32-eventlog'] = ['<= 0.6.5', require: false]
-  gems['win32-process'] =  ['<= 0.7.5', require: false]
-  gems['win32-security'] = ['<= 0.2.5', require: false]
-  gems['win32-service'] =  ['0.8.8', require: false]
-end
 
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params

--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ This module requires some additional modules, but it is highly likely that they
 are already installed on your puppet server. They are as follows:
 
 
-* `puppetlabs/apt` `6.0 - 8.0`
+* `puppetlabs/apt` `6.0 - 9.0`
 * `puppetlabs/augeas_core` `1.0.0 - 2.0.0`
-* `puppetlabs/stdlib` `5.0.0 - 6.0.0`
-* `puppetlabs/translate` `1.0.0 - 3.0.0`
+* `puppetlabs/stdlib` `5.0.0 - 9.0.0`
 * `puppetlabs/yumrepo_core` `1.0.0 - 2.0.0`
 
 ### Beginning with duo_unix

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
@@ -42,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
@@ -52,7 +54,7 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
     config.add_pr_wo_labels = true
     config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
     config.configure_sections = {
       "Changed" => {
         "prefix" => "### Changed",
@@ -60,11 +62,11 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
       },
       "Added" => {
         "prefix" => "### Added",
-        "labels" => ["feature", "enhancement"],
+        "labels" => ["enhancement", "feature"],
       },
       "Fixed" => {
         "prefix" => "### Fixed",
-        "labels" => ["bugfix"],
+        "labels" => ["bug", "documentation", "bugfix"],
       },
     }
   end
@@ -72,16 +74,15 @@ else
   desc 'Generate a Changelog from GitHub'
   task :changelog do
     raise <<EOM
-The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+The changelog tasks depends on recent features of the github_changelog_generator gem.
 Please manually add it to your .sync.yml for now, and run `pdk update`:
 ---
 Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
-        git: 'https://github.com/skywinder/github-changelog-generator'
-        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+        version: '~> 1.15'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
 EOM
   end
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,9 @@
 ---
 version: 1.1.x.{build}
+skip_branch_with_pr: true
 branches:
   only:
-    - master
+    - main
     - release
 skip_commits:
   message: /^\(?doc\)?.*/
@@ -16,16 +17,8 @@ init:
 environment:
   matrix:
     -
-      RUBY_VERSION: 24-x64
-      CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-    -
-      PUPPET_GEM_VERSION: ~> 5.0
-      RUBY_VERSION: 24
-      CHECK: parallel_spec
-    -
-      PUPPET_GEM_VERSION: ~> 5.0
-      RUBY_VERSION: 24-x64
-      CHECK: parallel_spec
+      RUBY_VERSION: 25-x64
+      CHECK: validate lint check rubocop
     -
       PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,15 @@
 #   variable before prompting the user for input. When $DUO_PASSCODE is 
 #   non-empty, it will override autopush.
 #   Default is "no"
+# @param proxy
+#   Whether to use a proxy.
+#
+# @param groups
+#   The groups to assign.
+#
+# @param show_diff
+#   Whether to display differences when the file changes.
+# 
 #
 class duo_unix (
   Enum['login', 'pam'] $usage,
@@ -99,8 +108,7 @@ class duo_unix (
   Optional[StdLib::Httpurl] $proxy            = undef,
   Optional[String] $groups                    = undef,
   Boolean $show_diff                          = true,
-) inherits duo_unix::params
-{
+) inherits duo_unix::params {
   if $manage_repo {
     include duo_unix::repo
   }
@@ -110,7 +118,7 @@ class duo_unix (
   # being able to use a param for the resource name were wrong
   #
   package { $duo_unix::duo_package:
-    ensure => $ensure
+    ensure => $ensure,
   }
 
   if ($duo_unix::usage == 'login') {
@@ -121,7 +129,6 @@ class duo_unix (
   } else {
     $owner = 'root'
     if ($manage_pam) {
-
       if ($manage_pam and $usage == 'login') {
         include duo_unix::pam_ssh_config
       }
@@ -137,6 +144,6 @@ class duo_unix (
     mode      => '0600',
     show_diff => $show_diff,
     content   => template('duo_unix/duo.conf.erb'),
-    require   => Package[$duo_unix::duo_package]
+    require   => Package[$duo_unix::duo_package],
   }
 }

--- a/manifests/pam_config.pp
+++ b/manifests/pam_config.pp
@@ -8,8 +8,7 @@
 #
 # @example
 #   include duo_unix::pam_config
-class duo_unix::pam_config inherits duo_unix::params
-{
+class duo_unix::pam_config inherits duo_unix::params {
   $aug_pam_path = "/files${duo_unix::params::pam_file}"
   $aug_match    = "${aug_pam_path}/*/module[. = '${duo_unix::params::pam_module}']"
 
@@ -22,7 +21,7 @@ class duo_unix::pam_config inherits duo_unix::params
           "ins 100 after ${aug_pam_path}/1",
           "set ${aug_pam_path}/100/type auth",
           "set ${aug_pam_path}/100/control '[success=1 default=ignore]'",
-          "set ${aug_pam_path}/100/module ${duo_unix::params::pam_module}"
+          "set ${aug_pam_path}/100/module ${duo_unix::params::pam_module}",
         ],
         require => Package[$duo_unix::params::duo_package],
         onlyif  => "match ${aug_match} size == 0";
@@ -35,7 +34,7 @@ class duo_unix::pam_config inherits duo_unix::params
           "ins 100 after ${aug_pam_path}/2",
           "set ${aug_pam_path}/100/type auth",
           "set ${aug_pam_path}/100/control sufficient",
-          "set ${aug_pam_path}/100/module ${duo_unix::params::pam_module}"
+          "set ${aug_pam_path}/100/module ${duo_unix::params::pam_module}",
         ],
         require => Package[$duo_unix::params::duo_package],
         onlyif  => "match ${aug_match} size == 0";

--- a/manifests/pam_ssh_config.pp
+++ b/manifests/pam_ssh_config.pp
@@ -10,8 +10,7 @@
 #
 # @example
 #   include duo_unix::pam_ssh_config
-class duo_unix::pam_ssh_config inherits duo_unix::params
-{
+class duo_unix::pam_ssh_config inherits duo_unix::params {
   augeas { 'Duo Security SSH Configuration':
     context => '/files/etc/ssh/sshd_config',
     changes => [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class duo_unix::params {
   $accept_env_factor  = 'no'
   $pam_unix_control   = 'requisite'
 
-  $pam_module = $::architecture ? {
+  $pam_module = $facts['os']['architecture'] ? {
     'i386'   => '/lib/security/pam_duo.so',
     'i686'   => '/lib/security/pam_duo.so',
     default  => '/lib64/security/pam_duo.so',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -70,7 +70,6 @@ class duo_unix::repo inherits duo_unix::params {
     'RedHat': {
       $osname = $facts['os']['name'] ? {
         'CentOS'       => 'CentOS',
-        'CentOSStream' => 'CentOSStream',
         default        => 'RedHat',
       }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -57,7 +57,6 @@ class duo_unix::repo inherits duo_unix::params {
         architecture => $architecture,
         key          => {
           id     => 'D8EC4E2058401AE5578C4B3F4B44CE3DFF696172',
-          ensure => 'refreshed',
           source => 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc',
         },
         require      => [

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -27,28 +27,25 @@ class duo_unix::repo inherits duo_unix::params {
       # provided by that binary here. We have to map our own codenames.
       #
       $codename_mapping = {
-        '12.04' => 'quantal',
-        '14.04' => 'trusty',
-        '16.04' => 'xenial',
         '18.04' => 'bionic',
         '20.04' => 'focal',
-        '6' => 'squeeze',
         '7' => 'wheezy',
         '8' => 'jessie',
         '9' => 'stretch',
         '10' => 'buster',
+        '11' => 'bullseye',
       }
 
       ensure_resource(
         'package',
         'apt-transport-https',
-        {'ensure' => 'present'}
+        { 'ensure' => 'present' }
       )
 
       ensure_resource(
         'package',
         'lsb-release',
-        {'ensure' => 'present'}
+        { 'ensure' => 'present' }
       )
 
       apt::source { 'duosecurity':
@@ -59,7 +56,7 @@ class duo_unix::repo inherits duo_unix::params {
         repos        => 'main',
         architecture => $architecture,
         key          => {
-          id     => '08C2A645DDF240B85844068D7A450864C1A07A85',
+          id     => 'D8EC4E2058401AE5578C4B3F4B44CE3DFF696172',
           source => 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc',
         },
         require      => [

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -69,8 +69,9 @@ class duo_unix::repo inherits duo_unix::params {
     }
     'RedHat': {
       $osname = $facts['os']['name'] ? {
-        'CentOS'    => 'CentOS',
-        default     => 'RedHat',
+        'CentOS'       => 'CentOS',
+        'CentOSStream' => 'CentOSStream',
+        default        => 'RedHat',
       }
 
       yumrepo { 'duosecurity':

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -57,6 +57,7 @@ class duo_unix::repo inherits duo_unix::params {
         architecture => $architecture,
         key          => {
           id     => 'D8EC4E2058401AE5578C4B3F4B44CE3DFF696172',
+          ensure => 'refreshed',
           source => 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc',
         },
         require      => [

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -7,8 +7,7 @@
 #
 # @example
 #   include duo_unix::ssh_config
-class duo_unix::ssh_config inherits duo_unix::params
-{
+class duo_unix::ssh_config inherits duo_unix::params {
   augeas { 'duo_ssh':
     context => '/files/etc/ssh/sshd_config',
     changes => [
@@ -21,7 +20,7 @@ class duo_unix::ssh_config inherits duo_unix::params
 
   if !defined(Service[$duo_unix::params::ssh_service]) {
     service { $duo_unix::params::ssh_service:
-      ensure => 'running'
+      ensure => 'running',
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "iu-duo_unix",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "author": "Anthony Vitacco <avitacco@iu.edu>",
   "summary": "Installs, configures, and manages Duo Unix",
   "license": "MIT",
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/augeas_core",
@@ -18,11 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
-    },
-    {
-      "name": "puppetlabs/translate",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 5.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/yumrepo_core",
@@ -33,33 +29,31 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
-        "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {
@@ -78,10 +72,10 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
-  "pdk-version": "1.18.0",
-  "template-url": "https://github.com/puppetlabs/pdk-templates/#master",
-  "template-ref": "heads/master-0-g88b05c7"
+  "pdk-version": "2.5.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
+  "template-ref": "tags/2.5.0-0-g369d483"
 }

--- a/provision.yaml
+++ b/provision.yaml
@@ -4,6 +4,7 @@ default:
   images:
     - 'ubuntu:20.04'
     - 'ubuntu:18.04'
+    - 'litmusimage/centos:7'
     - 'litmusimage/centos:stream8'
 ubuntu:
   provisioner: docker

--- a/provision.yaml
+++ b/provision.yaml
@@ -5,7 +5,6 @@ default:
     - 'ubuntu:20.04'
     - 'ubuntu:18.04'
     - 'litmusimage/centos:7'
-    - 'litmusimage/centos:stream8'
 ubuntu:
   provisioner: docker
   images:
@@ -20,4 +19,3 @@ centos:
   provisioner: docker
   images:
     - 'litmusimage/centos:7'
-    - 'litmusimage/centos:stream8'

--- a/provision.yaml
+++ b/provision.yaml
@@ -4,7 +4,6 @@ default:
   images:
     - 'ubuntu:20.04'
     - 'ubuntu:18.04'
-    - 'litmusimage/centos:8'
     - 'litmusimage/centos:stream8'
 ubuntu:
   provisioner: docker
@@ -20,5 +19,4 @@ centos:
   provisioner: docker
   images:
     - 'litmusimage/centos:7'
-    - 'litmusimage/centos:8'
     - 'litmusimage/centos:stream8'

--- a/provision.yaml
+++ b/provision.yaml
@@ -4,8 +4,8 @@ default:
   images:
     - 'ubuntu:20.04'
     - 'ubuntu:18.04'
+    - 'litmusimage/centos:8'
     - 'litmusimage/centos:stream8'
-    - 'litmusimage/centos:stream9'
 ubuntu:
   provisioner: docker
   images:
@@ -20,5 +20,5 @@ centos:
   provisioner: docker
   images:
     - 'litmusimage/centos:7'
+    - 'litmusimage/centos:8'
     - 'litmusimage/centos:stream8'
-    - 'litmusimage/centos:stream9'

--- a/provision.yaml
+++ b/provision.yaml
@@ -4,7 +4,8 @@ default:
   images:
     - 'ubuntu:20.04'
     - 'ubuntu:18.04'
-    - 'litmusimage/centos:8'
+    - 'litmusimage/centos:stream8'
+    - 'litmusimage/centos:stream9'
 ubuntu:
   provisioner: docker
   images:
@@ -13,10 +14,11 @@ ubuntu:
 debian:
   provisioner: docker
   images:
-    - 'debian:9'
     - 'debian:10'
+    - 'debian:11'
 centos:
   provisioner: docker
   images:
     - 'litmusimage/centos:7'
-    - 'litmusimage/centos:8'
+    - 'litmusimage/centos:stream8'
+    - 'litmusimage/centos:stream9'

--- a/spec/classes/duo_unix_spec.rb
+++ b/spec/classes/duo_unix_spec.rb
@@ -15,12 +15,12 @@ describe 'duo_unix' do
 
       it { is_expected.to compile.with_all_deps }
 
-      if os =~ %r{(?:debian|ubuntu).*}
+      if os.match? %r{(?:debian|ubuntu).*}
         it { is_expected.to contain_package('duo-unix').that_requires('Apt::Source[duosecurity]') }
         it { is_expected.to contain_apt__source('duosecurity') }
       end
 
-      if os =~ %r{(?:centos|redhat).*}
+      if os.match? %r{(?:centos|redhat).*}
         it { is_expected.to contain_package('duo_unix').that_requires('Yumrepo[duosecurity]') }
         it { is_expected.to contain_yumrepo('duosecurity') }
       end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -39,6 +39,10 @@ describe 'duo_unix::repo' do
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOS/$releasever/$basearch') }
       end
 
+      if os.match? %r{centosstream.*}
+        it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOSStream/$releasever/$basearch') }
+      end
+
       if os.match? %r{(redhat.*|rocky.*|alma.*)}
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/RedHat/$releasever/$basearch') }
       end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -9,14 +9,6 @@ describe 'duo_unix::repo' do
 
       if os.match? %r{ubuntu.*}
 
-        if os != 'ubuntu-18.04-x86_64'
-          it {
-            is_expected.to contain_apt__source('duosecurity')
-              .with_location('https://pkg.duosecurity.com/Ubuntu')
-              .with_architecture('i386,amd64')
-          }
-        end
-
         if os == 'ubuntu-18.04-x86_64'
           it {
             is_expected.to contain_apt__source('duosecurity')

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -27,6 +27,16 @@ describe 'duo_unix::repo' do
           }
         end
 
+        if os == 'ubuntu-20.04-x86_64'
+          it {
+            is_expected.to contain_apt__source('duosecurity')
+              .with_location('https://pkg.duosecurity.com/Ubuntu')
+              .with_release('focal')
+              .with_repos('main')
+              .with_architecture('amd64')
+          }
+        end
+
       end
 
       if os.match? %r{debian.*}

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -39,10 +39,6 @@ describe 'duo_unix::repo' do
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOS/$releasever/$basearch') }
       end
 
-      if os.match? %r{centosstream.*}
-        it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOSStream/$releasever/$basearch') }
-      end
-
       if os.match? %r{(redhat.*|rocky.*|alma.*)}
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/RedHat/$releasever/$basearch') }
       end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -7,7 +7,7 @@ describe 'duo_unix::repo' do
 
       it { is_expected.to compile.with_all_deps }
 
-      if os =~ %r{ubuntu.*}
+      if os.match? %r{ubuntu.*}
 
         if os != 'ubuntu-18.04-x86_64'
           it {
@@ -29,15 +29,15 @@ describe 'duo_unix::repo' do
 
       end
 
-      if os =~ %r{debian.*}
+      if os.match? %r{debian.*}
         it { is_expected.to contain_apt__source('duosecurity').with_location('https://pkg.duosecurity.com/Debian') }
       end
 
-      if os =~ %r{centos.*}
+      if os.match? %r{centos.*}
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOS/$releasever/$basearch') }
       end
 
-      if os =~ %r{(redhat.*|rocky.*|alma.*)}
+      if os.match? %r{(redhat.*|rocky.*|alma.*)}
         it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/RedHat/$releasever/$basearch') }
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,18 @@ RSpec.configure do |c|
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
   end
+
+  # Filter backtrace noise
+  backtrace_exclusion_patterns = [
+    %r{spec_helper},
+    %r{gems},
+  ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
 end
 
 # Ensures that a module is defined

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,7 +29,6 @@ else
     options[:keys] = node_config.dig('ssh', 'private-key') unless node_config.dig('ssh', 'private-key').nil?
     options[:password] = node_config.dig('ssh', 'password') unless node_config.dig('ssh', 'password').nil?
     # Support both net-ssh 4 and 5.
-    # rubocop:disable Metrics/BlockNesting
     options[:verify_host_key] = if node_config.dig('ssh', 'host-key-check').nil?
                                   # Fall back to SSH behavior. This variable will only be set in net-ssh 5.3+.
                                   if @strict_host_key_checking.nil? || @strict_host_key_checking


### PR DESCRIPTION
* Fixed unit tests
* Fixed puppet-lint issues
* Updated legacy facts
* Updated PDK
* Updated DUO GPG keys
* Updated README
* Dropped Ubuntu 14.04 support
* Dropped Ubuntu 16.04 support
* Dropped CentOS 6 support
* Dropped Debian 8 support
* Dropped Debian 9 support
* Added Ubuntu 20.04 support
* Added CentOS 9 support
* Added RedHat 9 support
* Added Debian 11 support
* Removed deprecated `puppetlabs/translate` module