### PR TITLE
Centos Stream Support

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -69,7 +69,7 @@ class duo_unix::repo inherits duo_unix::params {
     }
     'RedHat': {
       $osname = $facts['os']['name'] ? {
-        'CentOS'       => 'CentOS',
+        'CentOS'       => $facts['os']['distro']['id'],
         default        => 'RedHat',
       }
 

--- a/provision.yaml
+++ b/provision.yaml
@@ -5,6 +5,8 @@ default:
     - 'ubuntu:20.04'
     - 'ubuntu:18.04'
     - 'litmusimage/centos:7'
+    - 'litmusimage/centos:stream8'
+    - 'litmusimage/centos:stream9'
 ubuntu:
   provisioner: docker
   images:
@@ -19,3 +21,5 @@ centos:
   provisioner: docker
   images:
     - 'litmusimage/centos:7'
+    - 'litmusimage/centos:stream8'
+    - 'litmusimage/centos:stream9'

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -36,7 +36,13 @@ describe 'duo_unix::repo' do
       end
 
       if os.match? %r{centos.*}
-        it { is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOS/$releasever/$basearch') }
+        it {
+          if facts[:os]['distro']['id'] == 'CentOSStream'
+            is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOSStream/$releasever/$basearch')
+          else
+            is_expected.to contain_yumrepo('duosecurity').with_baseurl('https://pkg.duosecurity.com/CentOS/$releasever/$basearch')
+          end
+        }
       end
 
       if os.match? %r{(redhat.*|rocky.*|alma.*)}


### PR DESCRIPTION
Updates repo URL on CentOS Stream.  
- Fixes repo URL for CentOS 9 which is only available as CentOS Stream, fixing #30 
- CentOS 8 Stream will now use the CentOSStream repo URL now instead of the CentOS repo URL
- Updated provision.yaml to add the CentOS Stream 8 and 9 images.