### PR TITLE
Add cafile parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,9 @@
 # @param proxy
 #   Whether to use a proxy.
 #
+# @param cafile
+#   Path to CA file.
+#
 # @param groups
 #   The groups to assign.
 #
@@ -111,6 +114,7 @@ class duo_unix (
   Integer[1, 3]                       $prompts           = $duo_unix::params::prompts,
   Enum['no', 'yes']                   $accept_env_factor = $duo_unix::params::accept_env_factor,
   Optional[StdLib::Httpurl]           $proxy             = undef,
+  Optional[Stdlib::Absolutepath]      $cafile            = undef,
   Optional[String]                    $groups            = undef,
   Boolean                             $show_diff         = true,
 ) inherits duo_unix::params {

--- a/spec/classes/duo_unix_spec.rb
+++ b/spec/classes/duo_unix_spec.rb
@@ -29,6 +29,25 @@ describe 'duo_unix' do
         is_expected.to contain_file('/etc/duo/login_duo.conf')
           .with_ensure('file')
           .with_owner('sshd')
+          .without_content(%r{^cafile.+})
+      }
+    end
+
+    context 'with cafile defined' do
+      let(:params) do
+        {
+          'usage'  => 'login',
+          'ikey'   => 'testikey',
+          'skey'   => 'testskey',
+          'host'   => 'api-XXXXXXXX.duosecurity.com',
+          'cafile' => '/dne',
+        }
+      end
+      let(:facts) { os_facts }
+
+      it {
+        is_expected.to contain_file('/etc/duo/login_duo.conf')
+          .with_content(%r{^cafile=/dne})
       }
     end
 

--- a/templates/duo.conf.erb
+++ b/templates/duo.conf.erb
@@ -45,3 +45,8 @@ groups=<%= @groups %>
 ; HTTP proxy
 http_proxy=<%= @proxy %>
 <% end -%>
+<% if @cafile -%>
+
+; CA file
+cafile=<%= @cafile %>
+<% end -%>


### PR DESCRIPTION
Since duo_unix 1.7 the "cafile" parameter has been available and is useful to set when using a proxy that doesn't use a CA cert trusted by CA used by Duo.