### PR TITLE
Support Puppet 8, Drop Puppet 6, support stdlib 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ are already installed on your puppet server. They are as follows:
 
 * `puppetlabs/apt` `6.0 - 9.0`
 * `puppetlabs/augeas_core` `1.0.0 - 2.0.0`
-* `puppetlabs/stdlib` `5.0.0 - 9.0.0`
+* `puppetlabs/stdlib` `5.0.0 - 10.0.0`
 * `puppetlabs/yumrepo_core` `1.0.0 - 2.0.0`
 
 ### Beginning with duo_unix

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.0.0 < 9.0.0"
+      "version_requirement": ">= 5.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/yumrepo_core",
@@ -73,7 +73,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.0.0",


### PR DESCRIPTION
Unit tests locally passed:
```
Finished in 1 minute 58.27 seconds (files took 8.72 seconds to load)
228 examples, 0 failures
```