### PR TITLE
Duo passcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.bundle/
 /.idea/
 /.vagrant/
+/.config/
 /coverage/
 /bin/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Release 4.1.0
+* Adds pdk auto-added .config directory to gitignore
+* Format linting on manifests/ssh_config.pp
+* Adds 'with accept_env_factor => yes' context to spec/classes/duo_unix_spec.rb, to test when yes is specified for that class
+* Adds jammy and noble Ubuntu releases to Duo repo setup
+* Seemingly small but VERY significant changes to augeas blocks in manifests/ssh_config.pp to actually get this module to touch sshd_config at all, and to ensure idempotency when specifying an AcceptEnv option using Puppet's 'onlyif' f
+eature (augeas was NOT designed to do conveniently this) 
+
 ## Release 4.0.3
 * Accordingly updates sshd_config file if the accept_env_factor parameter is set to 'yes'
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -29,6 +29,8 @@ class duo_unix::repo inherits duo_unix::params {
       $codename_mapping = {
         '18.04' => 'bionic',
         '20.04' => 'focal',
+        '22.04' => 'jammy',
+        '23.10' => 'noble',
         '7' => 'wheezy',
         '8' => 'jessie',
         '9' => 'stretch',

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -20,7 +20,7 @@ class duo_unix::ssh_config inherits duo_unix::params {
   }
 
   if $duo_unix::params::accept_env_factor == 'yes' {
-    augeas {'duo_ssh_env':
+    augeas { 'duo_ssh_env':
       context => '/files/etc/ssh/sshd_config',
       changes => [
         'set AcceptEnv DUO_PASSCODE',

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -10,23 +10,27 @@
 #   include duo_unix::ssh_config
 class duo_unix::ssh_config inherits duo_unix::params {
   augeas { 'duo_ssh':
-    context => '/files/etc/ssh/sshd_config',
+    lens    => 'Sshd.lns',
+    incl    => '/etc/ssh/sshd_config',
     changes => [
-      'set ForceCommand /usr/sbin/login_duo',
-      'set PermitTunnel no',
+      'set /files/etc/ssh/sshd_config/ForceCommand /usr/sbin/login_duo',
+      'set /files/etc/ssh/sshd_config/PermitTunnel no',
     ],
     require => Package[$duo_unix::params::duo_package],
     notify  => Service[$duo_unix::params::ssh_service],
   }
-
+# If the env factor is set to yes, creates idempotency for AcceptEnv in augeas block with onlyif that
+# looks for pre-existing DUO_PASSCODE because even though it seems so, augeas wasn't designed for idempotency
   if $duo_unix::params::accept_env_factor == 'yes' {
     augeas { 'duo_ssh_env':
-      context => '/files/etc/ssh/sshd_config',
+      lens    => 'Sshd.lns',
+      incl    => '/etc/ssh/sshd_config',
       changes => [
-        'set AcceptEnv DUO_PASSCODE',
+        'set /files/etc/ssh/sshd_config/AcceptEnv[1000]/01 DUO_PASSCODE',
       ],
       require => Package[$duo_unix::params::duo_package],
       notify  => Service[$duo_unix::params::ssh_service],
+      onlyif  => "values /files/etc/ssh/sshd_config/AcceptEnv/* not_include 'DUO_PASSCODE'",
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "iu-duo_unix",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "author": "Anthony Vitacco <avitacco@iu.edu>, Mark Addonizio <maddoni@iu.edu>, Will Meredith <wmgithub@proton.me>",
   "summary": "Installs, configures, and manages Duo Unix",
   "license": "MIT",

--- a/spec/acceptance/ssh_config_spec.rb
+++ b/spec/acceptance/ssh_config_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper_acceptance'
+
+duo_config_file = '/etc/duo/login_duo.conf'
+
+pp_static_content = <<-PUPPETCODE
+    class { 'duo_unix':
+        manage_ssh => false,
+        usage      => 'login',
+        ikey       => 'ikey',
+        skey       => 'skey',
+        host       => 'host',
+        motd       => 'yes',
+    }
+PUPPETCODE
+
+expected_contents = <<-FILECONTENTS
+;
+; This file is managed by Puppet.
+; Any changes made will automatically be overwritten
+;
+
+[duo]
+; Duo integration key
+ikey=ikey
+
+; Duo secret key
+skey=skey
+
+; Duo API host
+host=host
+
+; Fallback local IP
+fallback_local_ip=no
+
+; Failure mode
+failmode=safe
+
+; Push info
+pushinfo=no
+
+; Auto push
+autopush=no
+
+; Prompts
+prompts=3
+
+; Accept environment factor
+accept_env_factor=no
+
+; MOTD display
+motd=yes
+FILECONTENTS
+
+def test_duo(pp, expected_contain, filename)
+  idempotent_apply(pp)
+  expect(file(filename)).to be_file
+  expect(file(filename)).to contain expected_contain
+end
+
+describe 'Duo configuration' do
+  context 'applying duo configuration'
+  it do
+    test_duo(pp_static_content, expected_contents, duo_config_file)
+  end
+end

--- a/spec/classes/duo_unix_spec.rb
+++ b/spec/classes/duo_unix_spec.rb
@@ -5,10 +5,10 @@ describe 'duo_unix' do
     context "on #{os}" do
       let(:params) do
         {
-          'usage' => 'login',
-          'ikey'  => 'testikey',
-          'skey'  => 'testskey',
-          'host'  => 'api-XXXXXXXX.duosecurity.com',
+          'usage'             => 'login',
+          'ikey'              => 'testikey',
+          'skey'              => 'testskey',
+          'host'              => 'api-XXXXXXXX.duosecurity.com',
         }
       end
       let(:facts) { os_facts }
@@ -48,6 +48,26 @@ describe 'duo_unix' do
       it {
         is_expected.to contain_file('/etc/duo/login_duo.conf')
           .with_content(%r{^cafile=/dne})
+      }
+    end
+
+    context 'with accept_env_factor => yes' do
+      let(:params) do
+        {
+          'usage'             => 'login',
+          'ikey'              => 'testikey',
+          'skey'              => 'testskey',
+          'host'              => 'api-XXXXXXXX.duosecurity.com',
+          'accept_env_factor' => 'yes',
+        }
+      end
+      let(:facts) { os_facts }
+
+      it {
+        is_expected.to contain_file('/etc/duo/login_duo.conf')
+          .with_content(%r{^accept_env_factor=yes$})
+        is_expected.to contain_file('/etc/ssh/sshd_config')
+          .with_content(%r{^AcceptEnv DUO_PASSCODE$})
       }
     end
 


### PR DESCRIPTION
Various insignificant code and linting changes, as well as a seemingly small but VERY significant changes to augeas blocks in manifests/ssh_config.pp to actually get this module to touch sshd_config at all, and to ensure idempotency when specifying an AcceptEnv option using Puppet's 'onlyif' feature (augeas was NOT designed to do conveniently this)