### PR TITLE
Duo passcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.bundle/
 /.idea/
 /.vagrant/
+/.config/
 /coverage/
 /bin/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 language: ruby
 cache: bundler
 before_install:
+  - sudo apt-get install -qq augeas-tools augeas-lenses libaugeas-dev
   - bundle -v
   - rm -f Gemfile.lock
   - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 language: ruby
 cache: bundler
 before_install:
-  - sudo apt-get install -qq augeas-tools augeas-lenses libaugeas-dev
+  - sudo apt-get install -qq ruby-augeas augeas-tools augeas-lenses libaugeas-dev
   - bundle -v
   - rm -f Gemfile.lock
   - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Release 4.1.0
+* Adds pdk auto-added .config directory to gitignore
+* Format linting on manifests/ssh_config.pp
+* Adds 'with accept_env_factor => yes' context to spec/classes/duo_unix_spec.rb, to test when yes is specified for that class
+* Adds jammy and noble Ubuntu releases to Duo repo setup
+* Seemingly small but VERY significant changes to augeas blocks in manifests/ssh_config.pp to actually get this module to touch sshd_config at all, and to ensure idempotency when specifying an AcceptEnv option using Puppet's 'onlyif' f
+eature (augeas was NOT designed to do conveniently this) 
+
 ## Release 4.0.3
 * Accordingly updates sshd_config file if the accept_env_factor parameter is set to 'yes'
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :development do
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 3.0',            require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
   gem "rspec-puppet-facts", '~> 2.0',            require: false
   gem "codecov", '~> 0.2',                       require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
@@ -40,6 +39,10 @@ end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
+end
+group :development, :system_tests do
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'rspec-puppet-augeas', :require => false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ module *currently* makes no attempt to support them.
 Pull requests are welcome, but all code must meet the following requirements
 
 * Is fully tested
+  * Note: Unit testing uses the [rspec-puppet-augeas](https://github.com/domcleal/rspec-puppet-augeas) Ruby gem, which requires the following local packages (at least in Debian-based environments) to be installed: `ruby-augeas augeas-tools augeas-lenses libaugeas-dev`
 * All tests **must** pass
 * Follows the [Puppet language style guide](https://puppet.com/docs/puppet/latest/style_guide.html)
 * All commits **must** be signed

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ If `usage` is set to `pam`, it will alter your pam config. Those changes are
 distribution-specific. To see exactly what is changed, please refer to the
 `manifests/pam_config.pp` file.
 
+If `accept_env_factor` is set to `yes`, it will configure your sshd_config
+ to allow DUO_PASSCODE as an AcceptEnv value to enable [out-of-band 2FA](https://help.duo.com/s/article/3313?language=en_US) 
+in the shell for use cases such as scp. **This feature is only possible if 
+`usage` is set to `login`.**
+
 ### Setup Requirements
 
 This module requires some additional modules, but it is highly likely that they
@@ -71,13 +76,16 @@ The very basic steps needed for a user to get the module up and running. This ca
 
 ```ruby
 class { 'duo_unix':
-  usage => 'login',
-  ikey  => 'your integration key',
-  skey  => 'your secret key',
-  host  => 'api-yourhost.duosecurity.com',
-  motd  => 'yes',
+  usage             => 'login',
+  ikey              => 'your integration key',
+  skey              => 'your secret key',
+  host              => 'api-yourhost.duosecurity.com',
+  motd              => 'yes',
+  accept_env_factor => 'no', 
 }
 ```
+**Note:** accept_env_factor is set to 'no' by default, but enables DUO_PASSCODE
+as desribed above for out-of-band 2FA when set to 'yes'
 
 ## Limitations
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -29,6 +29,8 @@ class duo_unix::repo inherits duo_unix::params {
       $codename_mapping = {
         '18.04' => 'bionic',
         '20.04' => 'focal',
+        '22.04' => 'jammy',
+        '23.10' => 'noble',
         '7' => 'wheezy',
         '8' => 'jessie',
         '9' => 'stretch',

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -20,7 +20,7 @@ class duo_unix::ssh_config inherits duo_unix::params {
   }
 
   if $duo_unix::params::accept_env_factor == 'yes' {
-    augeas {'duo_ssh_env':
+    augeas { 'duo_ssh_env':
       context => '/files/etc/ssh/sshd_config',
       changes => [
         'set AcceptEnv DUO_PASSCODE',

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -21,7 +21,7 @@ class duo_unix::ssh_config inherits duo_unix::params {
   }
 # If the env factor is set to yes, creates idempotency for AcceptEnv in augeas block with onlyif that
 # looks for pre-existing DUO_PASSCODE because even though it seems so, augeas wasn't designed for idempotency
-  if $duo_unix::params::accept_env_factor == 'yes' {
+  if $duo_unix::accept_env_factor == 'yes' {
     augeas { 'duo_ssh_env':
       lens    => 'Sshd.lns',
       incl    => '/etc/ssh/sshd_config',

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -10,23 +10,27 @@
 #   include duo_unix::ssh_config
 class duo_unix::ssh_config inherits duo_unix::params {
   augeas { 'duo_ssh':
-    context => '/files/etc/ssh/sshd_config',
+    lens    => 'Sshd.lns',
+    incl    => '/etc/ssh/sshd_config',
     changes => [
-      'set ForceCommand /usr/sbin/login_duo',
-      'set PermitTunnel no',
+      'set /files/etc/ssh/sshd_config/ForceCommand /usr/sbin/login_duo',
+      'set /files/etc/ssh/sshd_config/PermitTunnel no',
     ],
     require => Package[$duo_unix::params::duo_package],
     notify  => Service[$duo_unix::params::ssh_service],
   }
-
+# If the env factor is set to yes, creates idempotency for AcceptEnv in augeas block with onlyif that
+# looks for pre-existing DUO_PASSCODE because even though it seems so, augeas wasn't designed for idempotency
   if $duo_unix::params::accept_env_factor == 'yes' {
     augeas { 'duo_ssh_env':
-      context => '/files/etc/ssh/sshd_config',
+      lens    => 'Sshd.lns',
+      incl    => '/etc/ssh/sshd_config',
       changes => [
-        'set AcceptEnv DUO_PASSCODE',
+        'set /files/etc/ssh/sshd_config/AcceptEnv[1000]/01 DUO_PASSCODE',
       ],
       require => Package[$duo_unix::params::duo_package],
       notify  => Service[$duo_unix::params::ssh_service],
+      onlyif  => "values /files/etc/ssh/sshd_config/AcceptEnv/* not_include 'DUO_PASSCODE'",
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "iu-duo_unix",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "author": "Anthony Vitacco <avitacco@iu.edu>, Mark Addonizio <maddoni@iu.edu>, Will Meredith <wmgithub@proton.me>",
   "summary": "Installs, configures, and manages Duo Unix",
   "license": "MIT",

--- a/spec/acceptance/ssh_config_spec.rb
+++ b/spec/acceptance/ssh_config_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper_acceptance'
+
+duo_config_file = '/etc/duo/login_duo.conf'
+
+pp_static_content = <<-PUPPETCODE
+    class { 'duo_unix':
+        manage_ssh => false,
+        usage      => 'login',
+        ikey       => 'ikey',
+        skey       => 'skey',
+        host       => 'host',
+        motd       => 'yes',
+    }
+PUPPETCODE
+
+expected_contents = <<-FILECONTENTS
+;
+; This file is managed by Puppet.
+; Any changes made will automatically be overwritten
+;
+
+[duo]
+; Duo integration key
+ikey=ikey
+
+; Duo secret key
+skey=skey
+
+; Duo API host
+host=host
+
+; Fallback local IP
+fallback_local_ip=no
+
+; Failure mode
+failmode=safe
+
+; Push info
+pushinfo=no
+
+; Auto push
+autopush=no
+
+; Prompts
+prompts=3
+
+; Accept environment factor
+accept_env_factor=no
+
+; MOTD display
+motd=yes
+FILECONTENTS
+
+def test_duo(pp, expected_contain, filename)
+  idempotent_apply(pp)
+  expect(file(filename)).to be_file
+  expect(file(filename)).to contain expected_contain
+end
+
+describe 'Duo configuration' do
+  context 'applying duo configuration'
+  it do
+    test_duo(pp_static_content, expected_contents, duo_config_file)
+  end
+end

--- a/spec/classes/duo_unix_spec.rb
+++ b/spec/classes/duo_unix_spec.rb
@@ -51,26 +51,6 @@ describe 'duo_unix' do
       }
     end
 
-    context 'with accept_env_factor => yes' do
-      let(:params) do
-        {
-          'usage'             => 'login',
-          'ikey'              => 'testikey',
-          'skey'              => 'testskey',
-          'host'              => 'api-XXXXXXXX.duosecurity.com',
-          'accept_env_factor' => 'yes',
-        }
-      end
-      let(:facts) { os_facts }
-
-      it {
-        is_expected.to contain_file('/etc/duo/login_duo.conf')
-          .with_content(%r{^accept_env_factor=yes$})
-        is_expected.to contain_file('/etc/ssh/sshd_config')
-          .with_content(%r{^AcceptEnv DUO_PASSCODE$})
-      }
-    end
-
     context 'with usage pam and ensure latest' do
       let(:params) do
         {

--- a/spec/classes/duo_unix_spec.rb
+++ b/spec/classes/duo_unix_spec.rb
@@ -5,10 +5,10 @@ describe 'duo_unix' do
     context "on #{os}" do
       let(:params) do
         {
-          'usage' => 'login',
-          'ikey'  => 'testikey',
-          'skey'  => 'testskey',
-          'host'  => 'api-XXXXXXXX.duosecurity.com',
+          'usage'             => 'login',
+          'ikey'              => 'testikey',
+          'skey'              => 'testskey',
+          'host'              => 'api-XXXXXXXX.duosecurity.com',
         }
       end
       let(:facts) { os_facts }
@@ -48,6 +48,26 @@ describe 'duo_unix' do
       it {
         is_expected.to contain_file('/etc/duo/login_duo.conf')
           .with_content(%r{^cafile=/dne})
+      }
+    end
+
+    context 'with accept_env_factor => yes' do
+      let(:params) do
+        {
+          'usage'             => 'login',
+          'ikey'              => 'testikey',
+          'skey'              => 'testskey',
+          'host'              => 'api-XXXXXXXX.duosecurity.com',
+          'accept_env_factor' => 'yes',
+        }
+      end
+      let(:facts) { os_facts }
+
+      it {
+        is_expected.to contain_file('/etc/duo/login_duo.conf')
+          .with_content(%r{^accept_env_factor=yes$})
+        is_expected.to contain_file('/etc/ssh/sshd_config')
+          .with_content(%r{^AcceptEnv DUO_PASSCODE$})
       }
     end
 

--- a/spec/classes/ssh_config_spec.rb
+++ b/spec/classes/ssh_config_spec.rb
@@ -3,10 +3,35 @@ describe 'duo_unix::ssh_config' do
   let(:pre_condition) { "package { 'duo_unix': ensure => 'installed' } package { 'duo-unix': ensure => 'installed' }" }
 
   on_supported_os.each do |os, os_facts|
+    let :pre_condition do
+      "class { 'duo_unix':
+        usage => 'login',
+        ikey => 'testikey',
+        skey => 'testskey',
+        host => 'api-XXXXXXXX.duosecurity.com',
+        accept_env_factor => 'yes' }"
+    end
+
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
+    end
+
+    context 'with accept_env_factor => yes' do
+      let(:facts) { os_facts }
+
+      it {
+        is_expected.to contain_file('/etc/duo/login_duo.conf')
+          .with_content(%r{^accept_env_factor=yes$})
+      }
+      describe 'sshd' do
+        # Look for augeas['duo_ssh_env'] because sshd_config is a pre-existing and therefore not testable in the catalog by Rspec
+        # Testing for specific augeas changes is also not possible: See https://github.com/indiana-university/puppet-duo_unix/issues/45
+        it 'Finds duo_ssh_env augeas resource' do
+          is_expected.to contain_augeas('duo_ssh_env')
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ RSpec.configure do |c|
 end
 
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-augeas'
 require 'rspec-puppet-facts'
 
 require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
@@ -44,6 +45,7 @@ RSpec.configure do |c|
     Puppet.settings[:strict] = :warning
     Puppet.settings[:strict_variables] = true
   end
+  c.augeas_fixtures = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'augeas')
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!(0)


### PR DESCRIPTION
Various insignificant code and linting changes, as well as a seemingly small but VERY significant changes to augeas blocks in manifests/ssh_config.pp to actually get this module to touch sshd_config at all, and to ensure idempotency when specifying an AcceptEnv option using Puppet's 'onlyif' feature (augeas was NOT designed to do conveniently this)