### PR TITLE
duo passcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Release 4.2.4
+* Fixes idempotency in ssh_config and adds sshd_config_path as a params default.
+
 ## Release 4.2.3
 * Writes sshd config to file in sshd_config.d instead of sshd_config file
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class duo_unix::params {
   $accept_env_factor  = 'no'
   $pam_unix_control   = 'requisite'
   $duo_rsyslog        = false
+  $sshd_config_path   = '/etc/ssh/sshd_config.d/99-duo_sshd.conf'
 
   $pam_module = $facts['os']['architecture'] ? {
     'i386'   => '/lib/security/pam_duo.so',

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -3,19 +3,15 @@
 # @example
 #   include duo_unix::ssh_config
 class duo_unix::ssh_config inherits duo_unix::params {
-  $sshd_config_path = '/etc/ssh/sshd_config.d/99-duo_sshd.conf'
-  file { $sshd_config_path:
-    content => "ForceCommand /usr/sbin/login_duo\nPermitTunnel no",
+  if ($duo_unix::accept_env_factor == 'yes') {
+    $sshd_config_contents = "ForceCommand /usr/sbin/login_duo\nPermitTunnel no\nAcceptEnv DUO_PASSCODE"
+  } else {
+    $sshd_config_contents = "ForceCommand /usr/sbin/login_duo\nPermitTunnel no"
+  }
+  file { $duo_unix::params::sshd_config_path:
+    content => $sshd_config_contents,
     notify  => Service[$duo_unix::params::ssh_service],
     require => Package[$duo_unix::params::duo_package],
-  }
-  if $duo_unix::accept_env_factor == 'yes' {
-    file_line { 'acceptenv_duo_passcode':
-      path    => $sshd_config_path,
-      line    => 'AcceptEnv DUO_PASSCODE',
-      notify  => Service[$duo_unix::params::ssh_service],
-      require => Package[$duo_unix::params::duo_package],
-    }
   }
   if !defined(Service[$duo_unix::params::ssh_service]) {
     service { $duo_unix::params::ssh_service:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "iu-duo_unix",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "author": "Anthony Vitacco <avitacco@iu.edu>, Mark Addonizio <maddoni@iu.edu>, Will Meredith <wmgithub@proton.me>",
   "summary": "Installs, configures, and manages Duo Unix",
   "license": "MIT",

--- a/spec/classes/ssh_config_spec.rb
+++ b/spec/classes/ssh_config_spec.rb
@@ -33,6 +33,8 @@ describe 'duo_unix::ssh_config' do
       it {
         is_expected.to contain_file('/etc/duo/login_duo.conf')
           .with_content(%r{^accept_env_factor=yes$})
+        is_expected.to contain_file('/etc/ssh/sshd_config.d/99-duo_sshd.conf')
+          .with_content(%r{^AcceptEnv DUO_PASSCODE$})
       }
     end
   end


### PR DESCRIPTION
- **Changes ssh_config.pp to writes sshd config to file in sshd_config.d instead of sshd_config file, updates CHANGELOG.md and metadata.json accordingly.**
- **Fixes idempotency in ssh_config and adds sshd_config_path as a params default, updates CHANGELOG.md and metadata.json accordingly.**
