### PR TITLE
Ubuntu 24 - Change service name 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,6 @@ class duo_unix::params {
   case $facts['os']['family'] {
     'Debian', 'Ubuntu' : {
       $duo_package  = 'duo-unix'
-      $ssh_service  = 'sshd'
       $pam_file     = '/etc/pam.d/common-auth'
       $auth_logfile = '/var/log/auth.log'
       case $facts['os']['codename'] {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class duo_unix::params {
       $duo_package  = 'duo-unix'
       $pam_file     = '/etc/pam.d/common-auth'
       $auth_logfile = '/var/log/auth.log'
-      case $facts['os']['codename'] {
+      case $facts['os']['distro']['codename'] {
         'noble' : {
           $ssh_service  = 'ssh'
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,14 @@ class duo_unix::params {
       $ssh_service  = 'sshd'
       $pam_file     = '/etc/pam.d/common-auth'
       $auth_logfile = '/var/log/auth.log'
+      case $facts['os']['codename'] {
+        'noble' : {
+          $ssh_service  = 'ssh'
+        }
+        default: {
+          $ssh_service  = 'sshd'
+        }
+      }
     }
     'RedHat': {
       $duo_package = 'duo_unix'

--- a/spec/classes/pam_config_spec.rb
+++ b/spec/classes/pam_config_spec.rb
@@ -8,7 +8,7 @@ describe 'duo_unix::pam_config' do
     package { 'duo-unix':
       ensure => 'installed'
     }
-    service { 'sshd':
+    service { 'ssh':
       ensure => 'running'
     }"
   end

--- a/spec/classes/pam_config_spec.rb
+++ b/spec/classes/pam_config_spec.rb
@@ -8,7 +8,7 @@ describe 'duo_unix::pam_config' do
     package { 'duo-unix':
       ensure => 'installed'
     }
-    service { 'ssh':
+    service { 'sshd':
       ensure => 'running'
     }"
   end


### PR DESCRIPTION
On Ubuntu 24 ( noble ) the service SSHD renamed to SSH